### PR TITLE
Add support for reference_scripts

### DIFF
--- a/models/addresses.go
+++ b/models/addresses.go
@@ -74,15 +74,23 @@ type Asset struct {
 }
 
 type Utxo struct {
-	Address         string  `json:"address"`
-	Assets          []Asset `json:"assets"`
-	Datum           any     `json:"datum"`
-	Index           int64   `json:"index"`
-	ReferenceScript string  `json:"reference_script"`
-	TxHash          string  `json:"tx_hash"`
-	Slot            int64   `json:"slot"`
-	TxOutCbor       string  `json:"tx_out_cbor"`
+	Address         string          `json:"address"`
+	Assets          []Asset         `json:"assets"`
+	Datum           any             `json:"datum"`
+	Index           int64           `json:"index"`
+	ReferenceScript ReferenceScript `json:"reference_script"`
+	TxHash          string          `json:"tx_hash"`
+	Slot            int64           `json:"slot"`
+	TxOutCbor       string          `json:"tx_out_cbor"`
 }
+
+type ReferenceScript struct {
+	Bytes string                 `json:"bytes"`
+	Hash  string                 `json:"hash"`
+	JSON  map[string]interface{} `json:"json"`
+	Type  string                 `json:"type"`
+}
+
 type UtxosAtAddress struct {
 	Data        []Utxo            `json:"data"`
 	LastUpdated utils.LastUpdated `json:"last_updated"`


### PR DESCRIPTION
## Summary

Previously retrieving UTXOs for an addresses where the reference_script field wasn't null, it would fail.
By adding this struct we can now support them.

## Type of Change

Please mark the relevant option(s) for your pull request:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)

## Checklist

Please ensure that your pull request meets the following criteria:

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My code follows the project's coding style and best practices
- [x] My code is appropriately commented and includes relevant documentation
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
- [x] I have updated the documentation, if necessary

