### PR TITLE
fix: fixing tx submission

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -101,3 +101,14 @@ func (c *Client) post(url string, body interface{}) (*http.Response, error) {
 	req.Header.Set("Content-Type", "application/json")
 	return c.HTTPClient.Do(req)
 }
+
+func (c *Client) postBuffer(url string, buffer []byte) (*http.Response, error) {
+	req, err := http.NewRequest("POST", c.BaseUrl+url, bytes.NewBuffer(buffer))
+	req.Header.Set("Accept", "application/cbor")
+	req.Header.Add("api-key", c.apiKey)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/cbor")
+	return c.HTTPClient.Do(req)
+}

--- a/client/txmanager.go
+++ b/client/txmanager.go
@@ -26,7 +26,10 @@ func (c *Client) TxManagerHistory() (*[]models.TxManagerState, error) {
 
 func (c *Client) TxManagerSubmit(txHex string) (string, error) {
 	url := "/txmanager"
-	txBuffer, _ := hex.DecodeString(txHex)
+	txBuffer, err := hex.DecodeString(txHex)
+	if err != nil {
+		return "", err
+	}
 	resp, err := c.postBuffer(url, txBuffer)
 	if err != nil {
 		return "", err
@@ -42,7 +45,10 @@ func (c *Client) TxManagerSubmit(txHex string) (string, error) {
 
 func (c *Client) TxManagerSubmitTurbo(txHex string) (string, error) {
 	url := "/txmanager/turbosubmit"
-	txBuffer, _ := hex.DecodeString(txHex)
+	txBuffer, err := hex.DecodeString(txHex)
+	if err != nil {
+		return "", err
+	}
 	resp, err := c.postBuffer(url, txBuffer)
 	if err != nil {
 		return "", err

--- a/client/txmanager.go
+++ b/client/txmanager.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/maestro-org/go-sdk/models"
 )
@@ -22,34 +24,36 @@ func (c *Client) TxManagerHistory() (*[]models.TxManagerState, error) {
 	return &txManagerStates, nil
 }
 
-func (c *Client) TxManagerSubmit(cbor string) (models.BasicResponse, error) {
+func (c *Client) TxManagerSubmit(txHex string) (string, error) {
 	url := "/txmanager"
-	resp, err := c.post(url, cbor)
+	txBuffer, _ := hex.DecodeString(txHex)
+	resp, err := c.postBuffer(url, txBuffer)
 	if err != nil {
-		return models.BasicResponse{}, err
+		return "", err
 	}
 	defer resp.Body.Close()
-	var submitTx models.BasicResponse
-	err = json.NewDecoder(resp.Body).Decode(&submitTx)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return models.BasicResponse{}, err
+		return "", err
 	}
-	return submitTx, nil
+	txHash := string(bodyBytes)
+	return txHash, nil
 }
 
-func (c *Client) TxManagerSubmitTurbo(cbor string) (models.BasicResponse, error) {
+func (c *Client) TxManagerSubmitTurbo(txHex string) (string, error) {
 	url := "/txmanager/turbosubmit"
-	resp, err := c.post(url, cbor)
+	txBuffer, _ := hex.DecodeString(txHex)
+	resp, err := c.postBuffer(url, txBuffer)
 	if err != nil {
-		return models.BasicResponse{}, err
+		return "", err
 	}
 	defer resp.Body.Close()
-	var submitTx models.BasicResponse
-	err = json.NewDecoder(resp.Body).Decode(&submitTx)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return models.BasicResponse{}, err
+		return "", err
 	}
-	return submitTx, nil
+	txHash := string(bodyBytes)
+	return txHash, nil
 }
 
 func (c *Client) TxManagerState(txHash string) (*models.TxManagerState, error) {


### PR DESCRIPTION
## Summary

Fixing tx submission, with the fix, now we could submit the tx hex directly out from wallet signing (i.e. in format of `84a5008282582008d0f6443bb3fb78c3e015a6e622d...` to the sdk. The fix covers both normal submission and turbo submission

## Type of Change

Please mark the relevant option(s) for your pull request:

- [X] Bug fix (non-breaking change which fixes an issue)

## Testin

- [X] Local testing is performed, submitting a simple send lovelace tx on preprod.

