### PR TITLE
Fix: Error handling / TransactionDetail schema type

### DIFF
--- a/client/accounts.go
+++ b/client/accounts.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/maestro-org/go-sdk/models"
 	"github.com/maestro-org/go-sdk/utils"
@@ -20,6 +21,9 @@ func (c *Client) AccountAddresses(
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var accountAddresses models.AccountAddresses
@@ -43,6 +47,9 @@ func (c *Client) AccountAssets(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var accountAssets models.AccountAssets
 	err = json.NewDecoder(resp.Body).Decode(&accountAssets)
@@ -65,6 +72,9 @@ func (c *Client) StakeAccountHistory(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var stakeAccountHistory models.StakeAccountHistory
 	err = json.NewDecoder(resp.Body).Decode(&stakeAccountHistory)
@@ -82,6 +92,10 @@ func (c *Client) StakeAccountInformation(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
+
 	defer resp.Body.Close()
 	var stakeAccountInformation models.StakeAccountInformation
 	err = json.NewDecoder(resp.Body).Decode(&stakeAccountInformation)
@@ -104,6 +118,9 @@ func (c *Client) StakeAccountRewards(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var stakeAccountRewards models.StakeAccountRewards
 	err = json.NewDecoder(resp.Body).Decode(&stakeAccountRewards)
@@ -125,6 +142,9 @@ func (c *Client) StakeAccountUpdates(
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var stakeAccountUpdates models.StakeAccountUpdates

--- a/client/addresses.go
+++ b/client/addresses.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/maestro-org/go-sdk/models"
 	"github.com/maestro-org/go-sdk/utils"
@@ -13,6 +14,9 @@ func (c *Client) DecodeAddress(address string) (*models.DecodedAddress, error) {
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var decodedAddress models.DecodedAddress
@@ -28,6 +32,9 @@ func (c *Client) AddressTransactionCount(address string) (*models.AddressTransac
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var addressTransactionCount models.AddressTransactionCount
@@ -51,6 +58,9 @@ func (c *Client) AddressTransactions(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var addressTransactions models.AddressTransactions
 	err = json.NewDecoder(resp.Body).Decode(&addressTransactions)
@@ -72,6 +82,9 @@ func (c *Client) PaymentCredentialTransactions(
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var addressTransactions models.AddressTransactions
@@ -95,6 +108,9 @@ func (c *Client) UtxoReferencesAtAddress(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var utxoReferencesAtAddress models.UtxoReferencesAtAddress
 	err = json.NewDecoder(resp.Body).Decode(&utxoReferencesAtAddress)
@@ -116,6 +132,9 @@ func (c *Client) UtxosAtAddress(
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var utxosAtAddress models.UtxosAtAddress
@@ -140,6 +159,9 @@ func (c *Client) UtxosAtAddresses(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var utxosAtAddress models.UtxosAtAddress
 	err = json.NewDecoder(resp.Body).Decode(&utxosAtAddress)
@@ -161,6 +183,9 @@ func (c *Client) UtxosByPaymentCredential(
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var utxosAtAddress models.UtxosAtAddress

--- a/client/asset.go
+++ b/client/asset.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/maestro-org/go-sdk/models"
 	"github.com/maestro-org/go-sdk/utils"
@@ -20,6 +21,9 @@ func (c *Client) AccountsHoldingAsset(
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var accountsHoldingAsset models.AccountsHoldingAsset
@@ -43,6 +47,9 @@ func (c *Client) AddressHoldingAsset(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var addressesHoldingAsset models.AddressesHoldingAsset
 	err = json.NewDecoder(resp.Body).Decode(&addressesHoldingAsset)
@@ -57,6 +64,9 @@ func (c *Client) Asset(assetId string) (*models.AssetInformations, error) {
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var assetInformation models.AssetInformations
@@ -80,6 +90,9 @@ func (c *Client) AssetTransactions(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var assetTransactions models.AssetTransactions
 	err = json.NewDecoder(resp.Body).Decode(&assetTransactions)
@@ -102,6 +115,9 @@ func (c *Client) AssetUpdates(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var assetUpdates models.AssetUpdates
 	err = json.NewDecoder(resp.Body).Decode(&assetUpdates)
@@ -121,6 +137,9 @@ func (c *Client) AssetUtxos(assetId string, params *utils.Parameters) (*models.A
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var assetUtxos models.AssetUtxos

--- a/client/asset_policy.go
+++ b/client/asset_policy.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/maestro-org/go-sdk/models"
 	"github.com/maestro-org/go-sdk/utils"
@@ -20,6 +21,9 @@ func (c *Client) AccountsHoldingPolicy(
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var response models.AccountsHoldingPolicy
@@ -43,6 +47,9 @@ func (c *Client) AddressesHoldingPolicy(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var response models.AddressesHoldingPolicy
 	err = json.NewDecoder(resp.Body).Decode(&response)
@@ -64,6 +71,9 @@ func (c *Client) SpecificPolicyInformations(
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var response models.PolicyInformation
@@ -87,6 +97,9 @@ func (c *Client) TransactionsMovingPolicy(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var response models.PolicyTransactions
 	err = json.NewDecoder(resp.Body).Decode(&response)
@@ -108,6 +121,9 @@ func (c *Client) UtxosContainingPolicy(
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var response models.UtxosContainingPolicy

--- a/client/datum.go
+++ b/client/datum.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/maestro-org/go-sdk/models"
 )
@@ -12,6 +13,9 @@ func (c *Client) DatumFromHash(hash string) (*models.DatumFromHash, error) {
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var datum models.DatumFromHash

--- a/client/ecosystem.go
+++ b/client/ecosystem.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/maestro-org/go-sdk/models"
 )
@@ -12,6 +13,9 @@ func (c *Client) ResolveAdaHandle(handle string) (*models.BasicResponse, error) 
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var adaHandle models.BasicResponse

--- a/client/epochs.go
+++ b/client/epochs.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/maestro-org/go-sdk/models"
 )
@@ -12,6 +13,9 @@ func (c *Client) CurrentEpoch() (*models.EpochResp, error) {
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var currentEpoch models.EpochResp
@@ -27,6 +31,9 @@ func (c *Client) SpecificEpoch(epochNo int) (*models.EpochResp, error) {
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var specificEpoch models.EpochResp

--- a/client/general.go
+++ b/client/general.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
 
 	"github.com/maestro-org/go-sdk/models"
 )
@@ -11,6 +13,9 @@ func (c *Client) ChainTip() (*models.ChainTip, error) {
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var chainTip models.ChainTip
@@ -27,6 +32,9 @@ func (c *Client) EraHistory() (*models.EraHistory, error) {
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var eraHistory models.EraHistory
 	err = json.NewDecoder(resp.Body).Decode(&eraHistory)
@@ -42,6 +50,9 @@ func (c *Client) ProtocolParameters() (*models.ProtocolParameters, error) {
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var protocolParameters models.ProtocolParameters
 	err = json.NewDecoder(resp.Body).Decode(&protocolParameters)
@@ -56,6 +67,9 @@ func (c *Client) BlockChainStartTime() (models.BasicResponse, error) {
 	resp, err := c.get(url)
 	if err != nil {
 		return models.BasicResponse{}, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return models.BasicResponse{}, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var blockchainStartTime models.BasicResponse

--- a/client/linear_vesting.go
+++ b/client/linear_vesting.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/maestro-org/go-sdk/models"
 )
@@ -27,6 +28,9 @@ func (c *Client) LockAssets(lockBody LockBody) (*models.LockTransaction, error) 
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var lockTransaction models.LockTransaction
 	err = json.NewDecoder(resp.Body).Decode(&lockTransaction)
@@ -41,6 +45,9 @@ func (c *Client) StateOfVestingAssets(beneficiary string) (*[]models.VestingStat
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var vestingStates []models.VestingState
@@ -57,6 +64,9 @@ func (c *Client) CollectAssets(beneficiary string) (*models.CollectTransaction, 
 	resp, err := c.post(url, nil)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var collectTransaction models.CollectTransaction

--- a/client/pools.go
+++ b/client/pools.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/maestro-org/go-sdk/models"
 	"github.com/maestro-org/go-sdk/utils"
@@ -17,6 +18,9 @@ func (c *Client) ListOfRegisteredPools(params *utils.Parameters) (*models.Regist
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var registeredPools models.RegisteredPools
@@ -40,6 +44,9 @@ func (c *Client) StakePoolMintedBlocks(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var poolMintedBlocks models.PoolMintedBlocks
 	err = json.NewDecoder(resp.Body).Decode(&poolMintedBlocks)
@@ -61,6 +68,9 @@ func (c *Client) StakePoolDelegators(
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var stakePoolDelegators models.StakePoolDelegators
@@ -84,6 +94,9 @@ func (c *Client) StakePoolHistory(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var stakePoolHistory models.StakePoolHistory
 	err = json.NewDecoder(resp.Body).Decode(&stakePoolHistory)
@@ -98,6 +111,9 @@ func (c *Client) StakePoolInformation(poolId string) (*models.StakePoolInformati
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var stakePoolInformation models.StakePoolInformation
@@ -114,6 +130,9 @@ func (c *Client) StakePoolMetadata(poolId string) (*models.StakePoolMetadata, er
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var stakePoolMetadata models.StakePoolMetadata
 	err = json.NewDecoder(resp.Body).Decode(&stakePoolMetadata)
@@ -128,6 +147,9 @@ func (c *Client) StakePoolRelays(poolId string) (*models.StakePoolRelays, error)
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var stakePoolRelays models.StakePoolRelays
@@ -144,6 +166,9 @@ func (c *Client) StakePoolUpdates(poolId string) (*models.StakePoolUpdates, erro
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var stakePoolUpdates models.StakePoolUpdates

--- a/client/scripts.go
+++ b/client/scripts.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/maestro-org/go-sdk/models"
 )
@@ -12,6 +13,9 @@ func (c *Client) ScriptByHash(hash string) (*models.ScriptByHash, error) {
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var scriptByHash models.ScriptByHash

--- a/client/transactions.go
+++ b/client/transactions.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/maestro-org/go-sdk/models"
 	"github.com/maestro-org/go-sdk/utils"
@@ -13,6 +14,9 @@ func (c *Client) AddressByOutputReference(txHash string, index int) (*models.Bas
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var addressByOutputReference models.BasicResponse
@@ -30,6 +34,9 @@ func (c *Client) SubmitTx(cbor string) (models.BasicResponse, error) {
 	if err != nil {
 		return models.BasicResponse{}, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return models.BasicResponse{}, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var submitTx models.BasicResponse
 
@@ -46,6 +53,9 @@ func (c *Client) TransactionCbor(txHash string) (*models.BasicResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var transactionCbor models.BasicResponse
 	err = json.NewDecoder(resp.Body).Decode(&transactionCbor)
@@ -61,6 +71,9 @@ func (c *Client) TransactionDetails(txHash string) (*models.TransactionDetails, 
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var transactionDetails models.TransactionDetails
@@ -86,6 +99,9 @@ func (c *Client) TransactionOutputFromReference(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var transactionOutputFromReference models.TransactionOutputFromReference
 	err = json.NewDecoder(resp.Body).Decode(&transactionOutputFromReference)
@@ -109,6 +125,9 @@ func (c *Client) TransactionOutputsFromReferences(
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	var transactionOutputsFromReferences models.TransactionOutputsFromReferences
 	err = json.NewDecoder(resp.Body).Decode(&transactionOutputsFromReferences)
@@ -128,6 +147,9 @@ func (c *Client) EvaluateTx(txCbor string, AdditionalUtxos ...string) ([]models.
 	resp, err := c.post(url, body)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var redeemerEvals []models.RedeemerEvaluation

--- a/client/txmanager.go
+++ b/client/txmanager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/maestro-org/go-sdk/models"
 )
@@ -14,6 +15,9 @@ func (c *Client) TxManagerHistory() (*[]models.TxManagerState, error) {
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var txManagerStates []models.TxManagerState
@@ -34,6 +38,9 @@ func (c *Client) TxManagerSubmit(txHex string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -53,6 +60,9 @@ func (c *Client) TxManagerSubmitTurbo(txHex string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected error: %d", resp.Body)
+	}
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -67,6 +77,9 @@ func (c *Client) TxManagerState(txHash string) (*models.TxManagerState, error) {
 	resp, err := c.get(url)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
 	var txManagerState models.TxManagerState

--- a/models/transactions.go
+++ b/models/transactions.go
@@ -36,10 +36,10 @@ type TransactionDetail struct {
 	Metadata          any          `json:"metadata"`
 	Mint              []any        `json:"mint"`
 	Outputs           []Utxo       `json:"outputs"`
-	Redeemers         []Redeemers  `json:"redeemers"`
+	Redeemers         Redeemers    `json:"redeemers"`
 	ReferenceInputs   []any        `json:"reference_inputs"`
 	ScriptsExecuted   []Script     `json:"scripts_executed"`
-	ScriptsSuccesful  bool         `json:"scripts_succesful"`
+	ScriptsSuccessful bool         `json:"scripts_successful"`
 	Size              int64        `json:"size"`
 	TxHash            string       `json:"tx_hash"`
 	Withdrawals       []any        `json:"withdrawals"`


### PR DESCRIPTION
## Summary

- Fixing error handling, now it could return `err` on non 200 status
- Fixing incorrect schema type for `TransactionDetail`

## Type of Change

Please mark the relevant option(s) for your pull request:

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

- [X] Local testing on behaviour is conducted

