### PR TITLE
Fix:ExecutionUnits JSON struct tags and EvaluateTx return type

### DIFF
--- a/client/transactions.go
+++ b/client/transactions.go
@@ -159,7 +159,7 @@ func (c *Client) TransactionOutputsFromReferences(
 func (c *Client) EvaluateTx(
 	txCbor string,
 	AdditionalUtxos ...string,
-) ([]models.RedeemerEvaluation, error) {
+) (models.EvaluateTxResponse, error) {
 	url := "/transactions/evaluate"
 	body := models.EvaluateTx{
 		Cbor:            txCbor,
@@ -176,7 +176,7 @@ func (c *Client) EvaluateTx(
 		return nil, fmt.Errorf("unexpected error: %d", resp.Body)
 	}
 	defer resp.Body.Close()
-	var redeemerEvals []models.RedeemerEvaluation
+	var redeemerEvals models.EvaluateTxResponse
 	err = json.NewDecoder(resp.Body).Decode(&redeemerEvals)
 	if err != nil {
 		return nil, err

--- a/models/transactions.go
+++ b/models/transactions.go
@@ -92,8 +92,8 @@ type EvaluateTx struct {
 }
 
 type ExecutionUnits struct {
-	Mem   int64 `json:"Mem"`
-	Steps int64 `json:"Steps"`
+	Mem   int64 `json:"mem"`
+	Steps int64 `json:"steps"`
 }
 
 type RedeemerEvaluation struct {


### PR DESCRIPTION
## Summary

The `ExecutionUnits` struct has JSON field tags with incorrect capitalization. The JSON response received contains lowercase keys ('mem' and 'steps'), while the struct expects 'Mem' and 'Steps', causing a mismatch. As a result, the `EvaluateTx` function returns an empty slice. Additionally, replacing `[]models.RedeemerEvaluation` with `models.EvaluateTxResponse` in the `EvaluateTx` function improves consistency and readability.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

fixing the following issue https://github.com/maestro-org/go-sdk/issues/53
